### PR TITLE
fixing to ImageMagick version border between master and legacy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Go Imagick is a Go bind to ImageMagick's MagickWand C API.
 We support two compatibility branches:
 
 ```
-master (tag v2.x.x): >= ImageMagick 6.8.9
-legacy (tag v1.x.x): <= ImageMagick 6.8.8
+master (tag v2.x.x): >= ImageMagick 6.8.9-9
+legacy (tag v1.x.x): <= ImageMagick 6.8.9-8
 ```
 
 They map, respectively, through gopkg.in:


### PR DESCRIPTION
```
$ pwd
/home/yoya/gocode/src/gopkg.in/gographics/imagick.v2/imagick
$ for i in `seq 0 1`; do v="6.8.9-$i" ; echo === $v ;PKG_CONFIG_PATH=/home/yoya/ImageMagick/$v/lib/pkgconfig/ go install  ; done
=== 6.8.9-0
# gopkg.in/gographics/imagick.v2/imagick
could not determine kind of name for C.MagickAutoOrientImage
=== 6.8.9-1
# gopkg.in/gographics/imagick.v2/imagick
could not determine kind of name for C.MagickAutoOrientImage
$
```
